### PR TITLE
Updated MathJax CDN URL to official one

### DIFF
--- a/mathjax/api.py
+++ b/mathjax/api.py
@@ -6,7 +6,7 @@ from trac.core import *
 from genshi.builder import tag
 from genshi.core import Markup
 
-MATHJAX_URL = 'https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js'
+MATHJAX_URL = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js'
 
 class MathJaxPlugin(Component):
     """Renders mathematical equations using MathJax library.


### PR DESCRIPTION
I have updated the CDN URL as discussed in the accompanying ticket (https://github.com/mitar/trac-mathjax/issues/1).
